### PR TITLE
Adds webhook TLS generation script, manifests, and Makefile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 .venv
 .tox
 bin/*
+tls/*

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,50 @@
+# Copyright 2024 Canonical, Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+KUBECTL ?= kubectl
+
+all: generate-selfsigned-cert generate-webhook-secret set-webhook-cabundle deploy-webhook
+
+generate-selfsigned-cert:
+	bash -x ./scripts/generate-cert.sh
+
+generate-webhook-secret:
+	$(KUBECTL) create secret tls -n pebble-webhook mutating-pebble-webhook-tls \
+	  --cert=tls/server.crt \
+	  --key=tls/server.key \
+	  --dry-run=client \
+	  -o yaml > ./manifests/webhook-secret.yaml
+
+set-webhook-cabundle:
+	sed -i -e 's/caBundle: .*/caBundle: $(shell base64 -w 0 tls/ca.crt)/' manifests/webhook.yaml
+
+deploy-webhook:
+	# Create the namespace first.
+	$(KUBECTL) apply -f ./manifests/webhook-ns.yaml
+	for file in $(shell ls ./manifests); do \
+	  $(KUBECTL) apply -f "./manifests/$${file}"; \
+	done
+
+clean:
+	rm -rf tls
+	sed -i -e 's/tls.crt: .*/tls.crt: LS0t.../' manifests/webhook-secret.yaml
+	sed -i -e 's/tls.key: .*/tls.key: LS0t.../' manifests/webhook-secret.yaml
+	sed -i -e 's/caBundle: .*/caBundle: LS0t.../' manifests/webhook.yaml
+
+remove-webhook:
+	# Removing the namespace will remove everything from it.
+	$(KUBECTL) delete -f ./manifests/webhook-ns.yaml
+	$(KUBECTL) delete -f ./manifests/webhook.yaml
+
+.PHONY: all generate-selfsigned-cert generate-webhook-secret set-webhook-cabundle deploy-webhook clean remove-webhook

--- a/manifests/webhook-deployment.yaml
+++ b/manifests/webhook-deployment.yaml
@@ -1,0 +1,40 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: mutating-pebble-webhook
+  namespace: pebble-webhook
+spec:
+  selector:
+    matchLabels:
+      app: mutating-pebble-webhook
+  template:
+    metadata:
+      labels:
+        app: mutating-pebble-webhook
+    spec:
+      containers:
+        - image: ghcr.io/canonical/mutating-pebble-webhook:0.0.1-ck0
+          imagePullPolicy: Always
+          name: mutating-pebble-webhook
+          volumeMounts:
+            - name: tls
+              mountPath: "/etc/admission-webhook/tls"
+              readOnly: true
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 8443
+              scheme: HTTPS
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: 8443
+              scheme: HTTPS
+            initialDelaySeconds: 5
+            periodSeconds: 10
+      volumes:
+        - name: tls
+          secret:
+            secretName: mutating-pebble-webhook-tls

--- a/manifests/webhook-ns.yaml
+++ b/manifests/webhook-ns.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: pebble-webhook
+  labels:
+    skip-pebble-mount: "true"

--- a/manifests/webhook-secret.yaml
+++ b/manifests/webhook-secret.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+data:
+  tls.crt: LS0t...
+  tls.key: LS0t...
+kind: Secret
+metadata:
+  creationTimestamp: null
+  name: mutating-pebble-webhook-tls
+  namespace: pebble-webhook
+type: kubernetes.io/tls

--- a/manifests/webhook-svc.yaml
+++ b/manifests/webhook-svc.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: mutating-pebble-webhook-svc
+  namespace: pebble-webhook
+spec:
+  ports:
+    - port: 443
+      protocol: TCP
+      targetPort: 8443
+  selector:
+    app: mutating-pebble-webhook

--- a/manifests/webhook.yaml
+++ b/manifests/webhook.yaml
@@ -1,0 +1,26 @@
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+ name: "mutating-pebble-webhook.pebble-webhook.svc"
+webhooks:
+ - name: "mutating-pebble-webhook.pebble-webhook.svc"
+   namespaceSelector:
+     matchExpressions:
+       - key: skip-pebble-mount
+         operator: NotIn
+         values: ["true"]
+   rules:
+     - apiGroups: [""]
+       apiVersions: ["v1"]
+       operations: ["CREATE"]
+       resources: ["pods"]
+       scope: "*"
+   sideEffects: None
+   admissionReviewVersions: ["v1"]
+   clientConfig:
+     service:
+       namespace: pebble-webhook
+       name: mutating-pebble-webhook-svc
+       path: /add-pebble-mount
+       port: 443
+     caBundle: LS0t...

--- a/scripts/generate-cert.sh
+++ b/scripts/generate-cert.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+
+# Copyright 2024 Canonical, Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+DNS_NAME="${1:-mutating-pebble-webhook-svc.pebble-webhook.svc}"
+COMMON_NAME="$(echo $DNS_NAME | cut -d. -f1)"
+
+mkdir -p tls
+
+openssl genrsa -out tls/ca.key 2048
+
+openssl req -new -x509 \
+  -subj "/C=AU/CN=${COMMON_NAME}" \
+  -days 365 \
+  -key tls/ca.key \
+  -out tls/ca.crt
+
+openssl req -newkey rsa:2048 -nodes \
+  -subj "/C=AU/CN=${COMMON_NAME}" \
+  -keyout tls/server.key \
+  -out tls/server.csr
+
+openssl x509 -req \
+  -extfile <(printf "subjectAltName=DNS:${DNS_NAME}") \
+  -days 365 \
+  -in tls/server.csr \
+  -CA tls/ca.crt -CAkey tls/ca.key -CAcreateserial \
+  -out tls/server.crt


### PR DESCRIPTION
Adds the webhook-related manifest files. The webhook requires a secret containing a TLS certificate. One can be provided manually, or the included script can be used to generate a self-signed certificate.

Added a Makefile, simplifying the process of installing the webhook (make all).