### PR TITLE
Adds golangci-lint job

### DIFF
--- a/.github/workflows/golangci-lint.yaml
+++ b/.github/workflows/golangci-lint.yaml
@@ -1,0 +1,34 @@
+name: golangci-lint
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  golangci:
+    name: lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: stable
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v6
+        with:
+          version: v1.60
+
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: stable
+      - name: Build
+        run: go build -v -buildvcs=false -o bin/mutating-pebble-webhook ./cmd/

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,0 +1,28 @@
+output:
+  print-linter-name: true
+
+linters:
+  # Some linters are already enabled by default, no need to explicitly add them here.
+  # https://golangci-lint.run/usage/linters#enabled-by-default
+  enable:
+    # bugs / errors
+    - dupl
+    - gosec
+    - revive
+
+    # performance
+    - gocritic
+    - prealloc
+
+    # style, formatting
+    - goconst
+    - gofmt
+    - stylecheck
+    - tagliatelle
+
+linters-settings:
+  errcheck:
+    # Report about not checking of errors in type assertions: `a := b.(MyStruct)`.
+    # Such cases aren't reported by default.
+    # Default: false
+    check-type-assertions: true


### PR DESCRIPTION
Uses ``golangci/golangci-lint-action`` for linting the golang code, and adds a few additional linters.

Also builds the go binary to ensure there are no compilation errors.