### PR TITLE
Changes rock base to bare

### DIFF
--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -18,7 +18,7 @@ description: |
 license: Apache-2.0
 version: 0.0.1
 
-base: ubuntu@22.04
+base: bare
 build-base: ubuntu@22.04
 run-user: _daemon_
 
@@ -48,6 +48,7 @@ parts:
     build-environment:
       - GOOS: linux
       - GOARCH: $CRAFT_ARCH_BUILD_FOR
+      - CGO_ENABLED: 0
     go-generate:
       - ./cmd
     organize:

--- a/tests/integration/test_mutating_pebble_webhook.py
+++ b/tests/integration/test_mutating_pebble_webhook.py
@@ -82,6 +82,23 @@ def webhook_instance(module_instance: harness.Instance):
         module_instance, "mutating-pebble-webhook", "pebble-webhook"
     )
 
+    # Sanity check: make sure there isn't an error in Pebble that it couldn't start the service.
+    process = module_instance.exec(
+        [
+            "k8s",
+            "kubectl",
+            "logs",
+            "-n",
+            "pebble-webhook",
+            "deployment.apps/mutating-pebble-webhook",
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    assert '(Start service "mutating-pebble-webhook") failed' not in process.stdout
+
     yield module_instance
 
 


### PR DESCRIPTION
Switching to a bare-based image will reduce the overall image size and reduces attack surface area.

Adding the ``CGO_ENABLED=0`` will result in the go binary being statically linked, which means it won't need the ``/lib`` and ``/lib64`` folders to run. This allows us to switch the base image to bare, greatly reducing the image size.

Adds an extra sanity check during the integration tests, making sure that there is no error reported in Pebble while starting the service.