### PR TITLE
Removes -ckN suffix from deployment.yaml

### DIFF
--- a/manifests/webhook-deployment.yaml
+++ b/manifests/webhook-deployment.yaml
@@ -13,7 +13,7 @@ spec:
         app: mutating-pebble-webhook
     spec:
       containers:
-        - image: ghcr.io/canonical/mutating-pebble-webhook:0.0.1-ck0
+        - image: ghcr.io/canonical/mutating-pebble-webhook:0.0.1
           imagePullPolicy: Always
           name: mutating-pebble-webhook
           volumeMounts:


### PR DESCRIPTION
A recent change was merged, which affects how image tags are published. The latest rock image will also be published without the ``-ckN`` suffix.

This allows us to remove the suffix from the ``deployment.yaml`` file, meaning that the user may be able to always deploy the latest revision of the rock.