### PR TITLE
ci: Updates golangci-linter to v1.64

### DIFF
--- a/.github/workflows/golangci-lint.yaml
+++ b/.github/workflows/golangci-lint.yaml
@@ -21,7 +21,7 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v6
         with:
-          version: v1.60
+          version: v1.64
 
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
v1.60 is out of date, and it currently fails to run in the current repository. Updating it should solve the issue.